### PR TITLE
Fix descriptions of projects for maven central publishing

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -5,8 +5,8 @@ publishing {
         all {
             pom {
                 url = 'https://github.com/xenit-eu/contentgrid-configuration-discovery'
-                name = project.name
-                description = project.description
+                name = "${project.name}"
+                description = "${project.description}"
 
                 scm {
                     connection = 'scm:git:git@github.com:xenit-eu/contentgrid-configuration-discovery.git'
@@ -71,3 +71,5 @@ pluginManager.withPlugin('java-platform') {
         }
     }
 }
+
+check.dependsOn('checkMavenCentralRequirements')


### PR DESCRIPTION
The descriptions of the projects were eagerly evaluated, before they
were set by the build.gradle in each project.
Putting them in a groovy string will lazily-evaluate them at the point
when they are accessed.

Also add a the checkMavenCentralRequirements task to the check lifecycle
task, so the validity is always being checked before a merge to main.
