### PR TITLE
[ACC-1547] Add property that can be used to disable kubernetes configuration discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Configuration is automatically updated when changes are made in Kubernetes.
 
 This module can be automatically configured when a `KubernetesClient` bean is available. (e.g. when using spring-cloud-kubernetes)
 
-| Property                                                   | Type     | Description                                                                                                                                                                                                             |
-|------------------------------------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `contentgrid.configuration.discovery.kubernetes.namespace` | `string` | Sets the kubernetes namespace in which configuration discovery will be done. If unset, defaults to the namespace that the application is deployed in (or `default` if the application is running outside of Kubernetes) |
+| Property                                                   | Type      | Description                                                                                                                                                                                                             |
+|------------------------------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `contentgrid.configuration.discovery.kubernetes.enabled`   | `boolean` | Enables configuration discovery through Kubernetes (default `true`)                                                                                                                                                     |
+| `contentgrid.configuration.discovery.kubernetes.namespace` | `string`  | Sets the kubernetes namespace in which configuration discovery will be done. If unset, defaults to the namespace that the application is deployed in (or `default` if the application is running outside of Kubernetes) |
 
 
 Other configuration for the Kubernetes client should be done in [spring-cloud-kubernetes](https://docs.spring.io/spring-cloud-kubernetes/docs/current/reference/html/appendix.html), or a custom created `KubernetesClient`.

--- a/contentgrid-configuration-autoconfigure/src/main/java/com/contentgrid/configuration/spring/autoconfigure/kubernetes/ConfigurationDiscoveryKubernetesAutoConfiguration.java
+++ b/contentgrid-configuration-autoconfigure/src/main/java/com/contentgrid/configuration/spring/autoconfigure/kubernetes/ConfigurationDiscoveryKubernetesAutoConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.kubernetes.fabric8.Fabric8AutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnClass({KubernetesInformerObservableFactory.class, KubernetesClient.class})
 @ConditionalOnBean(KubernetesClient.class)
 @Import(KubernetesConfigurationMappingApplicationConfiguration.class)
+@ConditionalOnProperty(value = "contentgrid.configuration.discovery.kubernetes.enabled", matchIfMissing = true)
 public class ConfigurationDiscoveryKubernetesAutoConfiguration {
 
     @Bean(name = "com.contentgrid.configuration.kubernetes.fabric8.KubernetesInformerObservableFactory")

--- a/contentgrid-configuration-autoconfigure/src/test/java/com/contentgrid/configuration/spring/autoconfigure/kubernetes/ConfigurationDiscoveryKubernetesAutoConfigurationTest.java
+++ b/contentgrid-configuration-autoconfigure/src/test/java/com/contentgrid/configuration/spring/autoconfigure/kubernetes/ConfigurationDiscoveryKubernetesAutoConfigurationTest.java
@@ -51,6 +51,18 @@ class ConfigurationDiscoveryKubernetesAutoConfigurationTest {
     }
 
     @Test
+    void doesNotActivate_propertyDisabled() {
+        contextRunner
+                .withBean(KubernetesClient.class, () -> {
+                    return Mockito.mock(KubernetesClient.class, Mockito.RETURNS_MOCKS);
+                })
+                .withPropertyValues("contentgrid.configuration.discovery.kubernetes.enabled=false")
+                .run(context -> {
+                    assertThat(context.getBeanProvider(APPLICATION_OBSERVABLE)).isEmpty();
+                });
+    }
+
+    @Test
     void doesNotActivate_missingApplicationClass() {
         contextRunner
                 .withClassLoader(new FilteredClassLoader(ClassLoaderFilters.CONTENTGRID_APPS))


### PR DESCRIPTION
There needs to be a way to disable the autoconfiguration, since the
ContentGrid gateway also needs to be able to run in standalone mode with
statically configured routing for the management platform.
